### PR TITLE
Normalize public contacts and examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Please, follow these guidelines to make the contribution process easy and effect
 
 ## Contributor License Agreement
 
-You must sign the [Contributor License Agreement](https://pages.netcracker.com/cla-main.html) in order to contribute.
+You must sign the [Contributor License Agreement](https://github.com/Netcracker/qubership-workflow-hub/blob/main/CLA/cla.md) in order to contribute.
 
 ## Code of Conduct
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,13 @@
-# Security Reporting Process
+# Security Policy
+
+## Reporting a Vulnerability
 
 Please, report any security issue to `opensourcegroup@netcracker.com` where the issue will be triaged appropriately.
 
 If you know of a publicly disclosed security vulnerability please IMMEDIATELY email `opensourcegroup@netcracker.com`
 to inform the team about the vulnerability, so we may start the patch, release, and communication process.
 
-# Security Release Process
+## Security Release Process
 
 If the vulnerability is found in the latest stable release, then it would be fixed in patch version for that release.
 E.g., issue is found in 2.5.0 release, then 2.5.1 version with a fix will be released.

--- a/qubership-apihub-test-service/static/openapi.json
+++ b/qubership-apihub-test-service/static/openapi.json
@@ -4,24 +4,24 @@
     "title": "APIHUB registry public API",
     "description": "The API contract for APIHUB direct call\n",
     "contact": {
-      "url": "https://apihub.domain.com",
-      "email": "author@domain.com",
+      "url": "https://apihub.example.com",
+      "email": "author@example.com",
       "name": "Author"
     },
     "license": {
       "name": "Qubership",
-      "url": "https://domain.com"
+      "url": "https://example.com"
     },
     "version": "0.1.14",
     "x-nc-api-audience": "non-BWC"
   },
   "externalDocs": {
     "description": "Find out more about package",
-    "url": "https://wiki.domain.com"
+    "url": "https://wiki.example.com"
   },
   "servers": [
     {
-      "url": "https://{apihub}.domain.com/api/v2",
+      "url": "https://{apihub}.example.com/api/v2",
       "description": "APIHUB server",
       "variables": {
         "apihub": {
@@ -401,7 +401,7 @@
             "schema": {
               "type": "string",
               "format": "uri",
-              "example": "https://apihub.domain.com/portal"
+              "example": "https://apihub.example.com/portal"
             }
           }
         ],
@@ -1787,7 +1787,7 @@
                             "description": "Url of the Git repository.",
                             "type": "string",
                             "format": "URI",
-                            "example": "https://git.domain.com/apihub-registry"
+                            "example": "https://git.example.com/apihub-registry"
                           },
                           "cloudName": {
                             "description": "Name of the cloud for publication from Agent.",
@@ -1798,7 +1798,7 @@
                             "description": "Full address of the cloud from Agent.",
                             "type": "string",
                             "format": "URI",
-                            "example": "https://k8s.domain.com"
+                            "example": "https://k8s.example.com"
                           },
                           "namespace": {
                             "description": "Namespace of Agent's publication.",
@@ -5416,12 +5416,12 @@
                     "description": "Email address of the user",
                     "type": "string",
                     "format": "email",
-                    "example": "name.surname@domain.com"
+                    "example": "john.doe@example.com"
                   },
                   "name": {
                     "description": "Name of the user",
                     "type": "string",
-                    "example": "Name Surname"
+                    "example": "John Doe"
                   },
                   "password": {
                     "type": "string",
@@ -7489,13 +7489,13 @@
           "name": {
             "description": "Name of the user",
             "type": "string",
-            "example": "Name Surname"
+            "example": "John Doe"
           },
           "email": {
             "description": "Email address of the user",
             "type": "string",
             "format": "email",
-            "example": "name.surname@domain.com"
+            "example": "john.doe@example.com"
           },
           "avatarUrl": {
             "description": "Avatar of the user",
@@ -7568,7 +7568,7 @@
               "format": "email"
             },
             "example": [
-              "name.surname@domain.com"
+              "john.doe@example.com"
             ]
           },
           "role": {
@@ -8678,7 +8678,7 @@
                 "description": "Url of the Git repository.",
                 "type": "string",
                 "format": "URI",
-                "example": "https://git.domain.com/apihub-registry"
+                "example": "https://git.example.com/apihub-registry"
               },
               "labels": {
                 "description": "List of version labels.",
@@ -8699,7 +8699,7 @@
                 "description": "Full address of the cloud from Agent.",
                 "type": "string",
                 "format": "URI",
-                "example": "https://k8s-apps2.k8s.sdntest.domain.com"
+                "example": "https://k8s-apps2.k8s.sdntest.example.com"
               },
               "namespace": {
                 "description": "Namespace of Agent's publication.",
@@ -8830,7 +8830,7 @@
           "code": "APIHUB-3020",
           "reason": "packageNotFound",
           "message": "package with packageId = $packageId not found",
-          "referenceError": "https://wiki.domain.com/display/APIM/APIHUB+Error+codes",
+          "referenceError": "https://wiki.example.com/display/APIM/APIHUB+Error+codes",
           "status": 404
         }
       },
@@ -8841,7 +8841,7 @@
           "code": "APIHUB-3050",
           "reason": "PublishedVersionNotFound",
           "message": "Published version $version not found",
-          "referenceError": "https://wiki.domain.com/display/APIM/APIHUB+Error+codes",
+          "referenceError": "https://wiki.example.com/display/APIM/APIHUB+Error+codes",
           "status": 404
         }
       },
@@ -8852,7 +8852,7 @@
           "code": "APIHUB-3043",
           "reason": "FileNotFound",
           "message": "File for path $fileId not found",
-          "referenceError": "https://wiki.domain.com/display/APIM/APIHUB+Error+codes",
+          "referenceError": "https://wiki.example.com/display/APIM/APIHUB+Error+codes",
           "status": 404
         }
       },
@@ -8863,7 +8863,7 @@
           "code": "APIHUB-COMMON-4001",
           "reason": "Incorrect input parameters",
           "message": "Incorrect input parameters",
-          "referenceError": "https://wiki.domain.com/display/APIM/APIHUB+Error+codes",
+          "referenceError": "https://wiki.example.com/display/APIM/APIHUB+Error+codes",
           "status": 400
         }
       },
@@ -8874,7 +8874,7 @@
           "code": "APIHUB-8000",
           "reason": "InternalServerError",
           "message": "InternalServerError",
-          "refwrerenceError": "https://apihub.domain.com/error/APIHUB-COMMON-0001",
+          "refwrerenceError": "https://apihub.example.com/error/APIHUB-COMMON-0001",
           "status": 500
         }
       }

--- a/qubership-apihub-test-service/static/openapi.yaml
+++ b/qubership-apihub-test-service/static/openapi.yaml
@@ -19,19 +19,19 @@ info:
 
     '
   contact:
-    url: https://apihub.domain.com
-    email: author@domain.com
+    url: https://apihub.example.com
+    email: author@example.com
     name: Author
   license:
     name: Qubership
-    url: https://domain.com
+    url: https://example.com
   version: 0.1.14
   x-nc-api-audience: non-BWC
 externalDocs:
   description: Find out more about package
-  url: https://wiki.domain.com
+  url: https://wiki.example.com
 servers:
-  - url: https://{apihub}.domain.com/api/v2
+  - url: https://{apihub}.example.com/api/v2
     description: APIHUB server
     variables:
       apihub:
@@ -281,7 +281,7 @@ paths:
           schema:
             type: string
             format: uri
-            example: https://apihub.domain.com/portal
+            example: https://apihub.example.com/portal
       responses:
         '302':
           description: Moved Temporarily
@@ -1200,7 +1200,7 @@ paths:
                           description: Url of the Git repository.
                           type: string
                           format: URI
-                          example: https://git.domain.com/apihub-registry
+                          example: https://git.example.com/apihub-registry
                         cloudName:
                           description: Name of the cloud for publication from Agent.
                           type: string
@@ -1209,7 +1209,7 @@ paths:
                           description: Full address of the cloud from Agent.
                           type: string
                           format: URI
-                          example: https://k8s.domain.com
+                          example: https://k8s.example.com
                         namespace:
                           description: Namespace of Agent's publication.
                           type: string
@@ -3575,11 +3575,11 @@ paths:
                   description: Email address of the user
                   type: string
                   format: email
-                  example: name.surname@domain.com
+                  example: john.doe@example.com
                 name:
                   description: Name of the user
                   type: string
-                  example: Name Surname
+                  example: John Doe
                 password:
                   type: string
                   description: User password.
@@ -4951,12 +4951,12 @@ components:
         name:
           description: Name of the user
           type: string
-          example: Name Surname
+          example: John Doe
         email:
           description: Email address of the user
           type: string
           format: email
-          example: name.surname@domain.com
+          example: john.doe@example.com
         avatarUrl:
           description: Avatar of the user
           type: string
@@ -5011,7 +5011,7 @@ components:
             type: string
             format: email
           example:
-            - name.surname@domain.com
+            - john.doe@example.com
         role:
           description: Role name for assignment
           type: string
@@ -5936,7 +5936,7 @@ components:
               description: Url of the Git repository.
               type: string
               format: URI
-              example: https://git.domain.com/apihub-registry
+              example: https://git.example.com/apihub-registry
             labels:
               description: List of version labels.
               type: array
@@ -5952,7 +5952,7 @@ components:
               description: Full address of the cloud from Agent.
               type: string
               format: URI
-              example: https://k8s-apps2.k8s.sdntest.domain.com
+              example: https://k8s-apps2.k8s.sdntest.example.com
             namespace:
               description: Namespace of Agent's publication.
               type: string
@@ -6062,7 +6062,7 @@ components:
         code: APIHUB-3020
         reason: packageNotFound
         message: package with packageId = $packageId not found
-        referenceError: https://wiki.domain.com/display/APIM/APIHUB+Error+codes
+        referenceError: https://wiki.example.com/display/APIM/APIHUB+Error+codes
         status: 404
     VersionNotFound:
       description: Version not found by number. Response for the 404 error
@@ -6071,7 +6071,7 @@ components:
         code: APIHUB-3050
         reason: PublishedVersionNotFound
         message: Published version $version not found
-        referenceError: https://wiki.domain.com/display/APIM/APIHUB+Error+codes
+        referenceError: https://wiki.example.com/display/APIM/APIHUB+Error+codes
         status: 404
     FileNotFound:
       description: File not found by slug. Response for the 404 error
@@ -6080,7 +6080,7 @@ components:
         code: APIHUB-3043
         reason: FileNotFound
         message: File for path $fileId not found
-        referenceError: https://wiki.domain.com/display/APIM/APIHUB+Error+codes
+        referenceError: https://wiki.example.com/display/APIM/APIHUB+Error+codes
         status: 404
     IncorrectInputParameters:
       description: Incorrect input parameters
@@ -6089,7 +6089,7 @@ components:
         code: APIHUB-COMMON-4001
         reason: Incorrect input parameters
         message: Incorrect input parameters
-        referenceError: https://wiki.domain.com/display/APIM/APIHUB+Error+codes
+        referenceError: https://wiki.example.com/display/APIM/APIHUB+Error+codes
         status: 400
     InternalServerError:
       description: Default internal server error
@@ -6098,7 +6098,7 @@ components:
         code: APIHUB-8000
         reason: InternalServerError
         message: InternalServerError
-        refwrerenceError: https://apihub.domain.com/error/APIHUB-COMMON-0001
+        refwrerenceError: https://apihub.example.com/error/APIHUB-COMMON-0001
         status: 500
   securitySchemes:
     BearerAuth:


### PR DESCRIPTION
## Summary

- Normalize public contact files and example email addresses.
- Keep API support and repository feedback contacts aligned with approved addresses.
- Replace personal-looking examples with neutral example data where applicable.

## Changed files

- CONTRIBUTING.md
- SECURITY.md
- qubership-apihub-test-service/static/openapi.json
- qubership-apihub-test-service/static/openapi.yaml

## Commit

ddb1c3b chore: normalize public contacts and examples
 CONTRIBUTING.md                                   |  2 +-
 SECURITY.md                                       |  6 ++--
 qubership-apihub-test-service/static/openapi.json | 40 +++++++++++------------
 qubership-apihub-test-service/static/openapi.yaml | 40 +++++++++++------------
 4 files changed, 45 insertions(+), 43 deletions(-)
